### PR TITLE
Support custom root CA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.sw?
 docker-compose.yaml
 k8s/kustomization.yaml
+
+minio/

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ Studio will be deployed to on premise.
 5. Launch the stack `docker-compose up`
 
 Please see [`docker-compose`](/docker-compose/) and generated `docker-compose.yaml` for more details.
+
+## HTTPS
+
+For pointing custom https certificate use such command
+```
+./install.sh --url https://example.com \
+    --tls-cert-file server.crt \
+    --tls-key-file server.pem
+```

--- a/docker-compose/base.yaml
+++ b/docker-compose/base.yaml
@@ -7,7 +7,7 @@ services:
     restart: always
     environment:
       ALLOWED_HOSTS: "*"
-      SOCIAL_AUTH_REDIRECT_IS_HTTPS: "False"
+      SOCIAL_AUTH_REDIRECT_IS_HTTPS: "${SOCIAL_AUTH_REDIRECT_IS_HTTPS:-False}"
       SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "localhost:3000,localhost:8000"
       API_URL: ${API_URL:-http://localhost:8000/api}
 

--- a/docker-compose/minio.yaml
+++ b/docker-compose/minio.yaml
@@ -12,3 +12,5 @@ services:
     ports:
       - 9000:9000 # main port
       - 9001:9001 # web console port
+    volumes:
+      - ../minio:/data/:rw

--- a/docker-compose/traefik.yaml
+++ b/docker-compose/traefik.yaml
@@ -2,20 +2,32 @@ version: "3.4"
 
 services:
   traefik:
-    image: traefik:2.3
+    image: traefik:latest
     command:
-      - "--providers.docker=true"
-      - "--entrypoints.web.address=:80"
+      - --accesslog=true
+      - --entrypoints.web.address=:80
+      - --providers.docker=true
+    network_mode: service:api
     restart: always
-    ports:
-      - 80:80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
   api:
     labels:
       - traefik.http.routers.api.rule=(Host(`${STUDIO_HOSTNAME}`) && PathPrefix(`/api`))
+      - traefik.http.routers.api.service=api
+      - traefik.http.services.api.loadbalancer.server.port=8000
 
-  ui:
-    labels:
       - traefik.http.routers.ui.rule=Host(`${STUDIO_HOSTNAME}`)
+      - traefik.http.routers.ui.service=ui
+      - traefik.http.services.ui.loadbalancer.server.port=3000
+    extra_hosts:
+      - "${STUDIO_HOSTNAME}:127.0.0.1"
+    ports:
+      - 80:80
+
+  minio:
+    labels:
+      - traefik.http.routers.minio.rule=(Host(`${STUDIO_HOSTNAME}`) && PathPrefix(`/minio`))
+      - traefik.http.middlewares.minio1.stripprefix.prefixes=/minio
+      - traefik.http.routers.minio.middlewares=minio1@docker

--- a/docker-compose/traefik_https.yaml
+++ b/docker-compose/traefik_https.yaml
@@ -1,0 +1,27 @@
+version: "3.4"
+
+services:
+  traefik:
+    command:
+      - --accesslog=true
+      - --entrypoints.web.address=:80
+      - --entryPoints.websecure.address=:443
+      - --providers.docker=true
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --log=true
+      - --log.level=DEBUG
+    volumes:
+      - ${TLS_CERT_FILE}:/etc/traefik/server.crt
+      - ${TLS_KEY_FILE}:/etc/traefik/server.key
+      - ./traefik_https_conf.yaml:/etc/traefik/dynamic/traefik_https_conf.yaml
+
+  api:
+    labels:
+      - traefik.http.routers.api.tls=true
+      - traefik.http.routers.ui.tls=true
+    ports:
+      - 443:443
+
+  minio:
+    labels:
+      - traefik.http.routers.minio.tls=true

--- a/docker-compose/traefik_https_conf.yaml
+++ b/docker-compose/traefik_https_conf.yaml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: /etc/traefik/server.crt
+      keyFile: /etc/traefik/server.key


### PR DESCRIPTION
## Context

Current PR extends `install.sh` script with additional options that should help to set up studio-onpremise with https:// endpoint.

```
./install.sh --help
Usage: ./install.sh [OPTIONS]

OPTIONS:
  ...
  --url http://studio.example.com
  --tls-cert-file server.crt  (works only with --url)
  --tls-key-file server.key  (works only with --url)
  --ui-image url
  --backend-image url
```

* The option `--hostname` changed to `--url` and supports pointing url schema: http/https
* `--tls-cert-file` allows pointing server certificate
* `--tls-key-file` allows pointing private key
* `--ui-image` and `--backend-image` could be used for pointing self-build images

## How to use in practice

Following [README.md](https://github.com/iterative/studio-onpremise#how-to-use-custom-root-ca) instructions let's build custom ui and backend

### Build UI
```Dockerfile
FROM viewer_ui:latest

COPY ca.crt /usr/share/local/certificates/ca.crt
ENV NODE_EXTRA_CA_CERTS=/usr/share/local/certificates/ca.crt
```
```bash
docker build -t ui_onpremise .
```

### Build backend
```Dockerfile
FROM viewer_backend:latest

COPY ca.crt /usr/share/local/certificates/ca.crt
RUN cat /usr/share/local/certificates/ca.crt >> /usr/local/lib/python3.8/site-packages/certifi/cacert.pem
```
```bash
docker build -t backend_onpremise .
```

### Install
```bash
  ./install.sh \
      --url https://studio.local \
      --env-file .env \
      --tls-cert-file ../studio.local/server.crt \
      --tls-key-file ../studio.local/server.key \
      --ui-image ui_onpremise \
      --backend-image backend_onpremise
```

### Launch
```bash
docker-compose up
```
* Minio will be accessible on `/minio` path, as an example: https://studio.local/minio