### PR TITLE
Pass GITHUB_API_URL environment variable to api container

### DIFF
--- a/docker-compose/base.yaml
+++ b/docker-compose/base.yaml
@@ -23,6 +23,8 @@ services:
         GITHUB_APP_SECRET_KEY: ${GITHUB_APP_SECRET_KEY:-}
         GITHUB_APP_PRIVATE_KEY_PEM: ${GITHUB_APP_PRIVATE_KEY_PEM:-}
         GITHUB_URL: ${GITHUB_URL:-}
+        GITHUB_API_URL: ${GITHUB_API_URL:-}
+
         GITHUB_WEBHOOK_URL: ${GITHUB_WEBHOOK_URL:-http://localhost:8000/webhook/github/}
         GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-github_secret}
 


### PR DESCRIPTION
The `GITHUB_API_URL` environment variable was missing in the base docker-compose template. This is needed for GitHub Enterprise users so that it uses their API and not `api.github.com`